### PR TITLE
rename depth_topic (from "image_rect_raw" to "image_raw")

### DIFF
--- a/face_detector/launch/face_detector.rgbd.launch
+++ b/face_detector/launch/face_detector.rgbd.launch
@@ -2,7 +2,7 @@
 
   <arg name="camera" default="camera" />
   <arg name="image_topic" default="image_rect_color" />
-  <arg name="depth_topic" default="image_rect_raw" />
+  <arg name="depth_topic" default="image_raw" />
   <arg name="fixed_frame" default="camera_rgb_optical_frame" />
   <arg name="depth_ns" default="depth_registered" />
 


### PR DESCRIPTION
openni_launch's default depth_registered topic name is /camera/depth_registered/image_raw, so I think depth_topic should be also image_raw.
