### PR TITLE
Added linking for people_tracking_filter. 

### DIFF
--- a/people_tracking_filter/CMakeLists.txt
+++ b/people_tracking_filter/CMakeLists.txt
@@ -65,6 +65,8 @@ target_link_libraries(people_tracker
    people_tracking_filter ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${BFL_LIBRARIES}
 )
 
+target_link_libraries(people_tracking_filter ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${BFL_LIBRARIES})
+
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
This is needed for OS X compilation.
