### PR TITLE
Fix handling of scans with negative angle increment

### DIFF
--- a/leg_detector/src/laser_processor.cpp
+++ b/leg_detector/src/laser_processor.cpp
@@ -248,7 +248,7 @@ ScanProcessor::splitConnected(float thresh)
       list<Sample*>::iterator s_q = sample_queue.begin();
       while (s_q != sample_queue.end())
       {
-        int expand = (int)(asin(thresh / (*s_q)->range) / scan_.angle_increment);
+        int expand = (int)(asin(thresh / (*s_q)->range) / std::abs(scan_.angle_increment));
 
         SampleSet::iterator s_rest = (*c_iter)->begin();
 


### PR DESCRIPTION
`ScanProcessor::splitConnected(float thresh)` currently fails to generate clusters if the angle_increment in the laser scan message has a negative value. Negative angle increments are set by [some laser scanner drivers](https://github.com/rhuitl/laser_drivers/blob/master/sicktoolbox_wrapper2/ros/sicklms/sicklms2xx.cpp) when the sensor is mounted upside down and an `inverted` option is set.

This pull request fixes that, by ensuring that the `expand` integer remains positive.
