### PR TITLE
Install missing param directory

### DIFF
--- a/face_detector/CMakeLists.txt
+++ b/face_detector/CMakeLists.txt
@@ -66,7 +66,7 @@ install(DIRECTORY include/face_detector/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 
-install(DIRECTORY launch
+install(DIRECTORY launch param
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/
 )
 


### PR DESCRIPTION
Using DEB, [face_detector.rgbd.launch](https://github.com/wg-perception/people/blob/9d99dbd8d9fa4124f270742eac2a5f12e829eeda/face_detector/launch/face_detector.rgbd.launch#L21) fails due to the `param` folder.

```
 <rosparam command="load" file="$(find face_detector)/param/classifier.yaml"/>
```

```
$ dpkg -p ros-indigo-face-detector | grep Ver
Version: 1.0.8-0trusty-20150729-2019-+0000
```
