### PR TITLE
[face_detector] Clarify args in a launch

### DIFF
--- a/face_detector/launch/face_detector.rgbd.launch
+++ b/face_detector/launch/face_detector.rgbd.launch
@@ -1,10 +1,16 @@
 <launch>
 
+  <!-- Following args `camera` and `depth_ns` together consist the namespace prefix, and the args `*_topic` and `fixed_frame` make the body of the topic for face_detector node to subscribe. In the example below, you're subscribing to: 
+
+        /camera/depth_ns/image_rect_color
+        /camera/depth_ns/image_rect_raw 
+        /camera/depth_ns/camera_rgb_optical_frame
+   -->
   <arg name="camera" default="camera" />
+  <arg name="depth_ns" default="depth_registered" />
   <arg name="image_topic" default="image_rect_color" />
   <arg name="depth_topic" default="image_rect_raw" />
   <arg name="fixed_frame" default="camera_rgb_optical_frame" />
-  <arg name="depth_ns" default="depth_registered" />
 
   <!--include file="$(find openni_launch)/launch/openni.launch"/-->
   <node name="$(anon dynparam)" pkg="dynamic_reconfigure" type="dynparam" args="set_from_parameters $(arg camera)/driver">
@@ -13,10 +19,11 @@
 
  <node pkg="face_detector" type="face_detector" name="face_detector" output="screen">
     <remap from="camera" to="$(arg camera)" />
+    <remap from="depth_ns" to="$(arg depth_ns)" />
     <remap from="image_topic" to="$(arg image_topic)" />
     <remap from="depth_topic" to="$(arg depth_topic)" />
-    <remap from="depth_ns" to="$(arg depth_ns)" />
     <param name="fixed_frame" type="string" value="$(arg fixed_frame)" />
+
     <param name="classifier_name" type="string" value="frontalface" />
     <rosparam command="load" file="$(find face_detector)/param/classifier.yaml"/>
     <param name="classifier_reliability" type="double" value="0.9"/>
@@ -25,7 +32,6 @@
     <param name="do_display" type="bool" value="false" />
     <param name="use_rgbd" type="bool" value="true" />
     <param name="approximate_sync" type="bool" value="true" />
-	 
   </node>
 
 </launch>


### PR DESCRIPTION
Multiple args in launch files compose topics to subscribe, which I had to spend some time on to figure out with a lack of document about that. This change in a launch file, as well as [this change on wiki](http://wiki.ros.org/action/info/face_detector?action=diff&rev2=21&rev1=20), hopefully gives better instruction.

For other launch files in the same `face_detector/launch` directory, I can add the similar changes to this PR if the initial commit looks good.
