### PR TITLE
More flexibility and reusability to launch files

### DIFF
--- a/face_detector/launch/face_detector.narrow.launch
+++ b/face_detector/launch/face_detector.narrow.launch
@@ -5,18 +5,10 @@
   <arg name="image_topic" default="image_rect" />
   <arg name="fixed_frame" default="narrow_stereo_optical_frame" />
 
-  <node pkg="face_detector" type="face_detector" name="face_detector" output="screen">
+  <include file="$(find face_detector)/launch/face_detector_common.launch">
     <remap from="camera" to="$(arg camera)" />
-    <remap from="image" to="$(arg image_topic)" />
-    <param name="fixed_frame" type="string" value="$(arg fixed_frame)" />
-    <param name="classifier_name" type="string" value="frontalface" />
-    <rosparam command="load" file="$(find face_detector)/param/classifier.yaml"/>
-    <param name="classifier_reliability" type="double" value="0.9"/>
-    <param name="do_continuous" type="bool" value="true" />
-    <param name="do_publish_faces_of_unknown_size" type="bool" value="false" />	
-    <param name="do_display" type="bool" value="false" />
-    <param name="use_rgbd" type="bool" value="false" />
-    <param name="approximate_sync" type="bool" value="false" />
-  </node>
+    <remap from="image_topic" to="$(arg image_topic)" />
+    <param name="fixed_frame" value="$(arg fixed_frame)" />
+  </include>
 
 </launch>

--- a/face_detector/launch/face_detector.rgbd.launch
+++ b/face_detector/launch/face_detector.rgbd.launch
@@ -17,21 +17,21 @@
     <param name="depth_registration" type="bool" value="true" />
   </node>
 
- <node pkg="face_detector" type="face_detector" name="face_detector" output="screen">
+  <include file="$(find face_detector)/launch/face_detector_common.launch">
     <remap from="camera" to="$(arg camera)" />
     <remap from="depth_ns" to="$(arg depth_ns)" />
     <remap from="image_topic" to="$(arg image_topic)" />
     <remap from="depth_topic" to="$(arg depth_topic)" />
-    <param name="fixed_frame" type="string" value="$(arg fixed_frame)" />
 
-    <param name="classifier_name" type="string" value="frontalface" />
-    <rosparam command="load" file="$(find face_detector)/param/classifier.yaml"/>
-    <param name="classifier_reliability" type="double" value="0.9"/>
-    <param name="do_continuous" type="bool" value="true" />
-    <param name="do_publish_faces_of_unknown_size" type="bool" value="false" />	
-    <param name="do_display" type="bool" value="false" />
-    <param name="use_rgbd" type="bool" value="true" />
-    <param name="approximate_sync" type="bool" value="true" />
-  </node>
+    <param name="fixed_frame" value="$(arg fixed_frame)" />
+    <rosparam command="load" file="$(arg paramfile_classifier)"/>
+    <param name="classifier_name" value="$(arg classifier_name)" />
+    <param name="classifier_reliability" value="$(arg classifier_reliability)"/>
+    <param name="do_continuous" value="$(arg do_continuous)" />
+    <param name="do_publish_faces_of_unknown_size" value="$(arg do_publish_faces_of_unknown_size)" />	
+    <param name="do_display" value="$(arg do_display)" />
+    <param name="use_rgbd" value="$(arg use_rgbd)" />
+    <param name="approximate_sync" value="$(arg approximate_sync)" />
+  </include>
 
 </launch>

--- a/face_detector/launch/face_detector.rgbd.launch
+++ b/face_detector/launch/face_detector.rgbd.launch
@@ -1,10 +1,9 @@
 <launch>
 
-  <!-- Following args `camera` and `depth_ns` together consist the namespace prefix, and the args `*_topic` and `fixed_frame` make the body of the topic for face_detector node to subscribe. In the example below, you're subscribing to: 
+  <!-- Following args `camera` and `depth_ns` together consist the namespace prefix, and the args `*_topic` make the body of the topic for face_detector node to subscribe. In the example below, you're subscribing to: 
 
-        /camera/depth_ns/image_rect_color
+        /camera/rgb/image_rect_color
         /camera/depth_ns/image_rect_raw 
-        /camera/depth_ns/camera_rgb_optical_frame
    -->
   <arg name="camera" default="camera" />
   <arg name="depth_ns" default="depth_registered" />

--- a/face_detector/launch/face_detector.rgbd.launch
+++ b/face_detector/launch/face_detector.rgbd.launch
@@ -6,6 +6,7 @@
         /camera/depth_ns/image_rect_raw 
    -->
   <arg name="camera" default="camera" />
+  <arg name="rgb_ns" default="rgb" />  
   <arg name="depth_ns" default="depth_registered" />
   <arg name="image_topic" default="image_rect_color" />
   <arg name="depth_topic" default="image_rect_raw" />

--- a/face_detector/launch/face_detector.wide.launch
+++ b/face_detector/launch/face_detector.wide.launch
@@ -4,20 +4,16 @@
   <arg name="camera" default="wide_stereo" />
   <arg name="image_topic" default="image_rect" />
   <arg name="fixed_frame" default="wide_stereo_optical_frame" />
-
-  <node pkg="face_detector" type="face_detector" name="face_detector" output="screen">
+  <arg name="do_continuous" default="true" />  
+  <arg name="use_rgbd" default="false" />  
+  <arg name="approximate_sync" default="false" />
+  
+  <include file="$(find face_detector)/launch/face_detector_common.launch">
     <remap from="camera" to="$(arg camera)" />
-    <remap from="image" to="$(arg image_topic)" />	
+    <remap from="image" to="$(arg image_topic)" />
     <param name="fixed_frame" type="string" value="$(arg fixed_frame)" />
-    <param name="classifier_name" type="string" value="frontalface" />
-    <rosparam command="load" file="$(find face_detector)/param/classifier.yaml"/>
-    <param name="classifier_reliability" type="double" value="0.9"/>
-    <param name="do_continuous" type="bool" value="true" />
-    <param name="do_publish_faces_of_unknown_size" type="bool" value="false" />	
-    <param name="do_display" type="bool" value="false" />
-    <param name="use_rgbd" type="bool" value="false" />
-    <param name="approximate_sync" type="bool" value="false" />
-	 
-  </node>
-
+    <param name="do_continuous" type="bool" value="$(arg do_continuous)" />
+    <param name="use_rgbd" type="bool" value="$(arg use_rgbd)" />
+    <param name="approximate_sync" type="bool" value="$(arg approximate_sync)" />  
+  </include>
 </launch>

--- a/face_detector/launch/face_detector_action.rgbd.launch
+++ b/face_detector/launch/face_detector_action.rgbd.launch
@@ -9,19 +9,9 @@
     <param name="depth_registration" type="bool" value="true" />
   </node>
 
-  <node pkg="face_detector" type="face_detector" name="face_detector_action" output="screen">
+  <include file="$(find face_detector)/launch/face_detector_common.launch">
     <remap from="camera" to="$(arg camera)" />
-    <remap from="image" to="$(arg image_topic)" />
-    <param name="fixed_frame" type="string" value="$(arg fixed_frame)" />
-    <param name="classifier_name" type="string" value="frontalface" />
-    <rosparam command="load" file="$(find face_detector)/param/classifier.yaml"/>
-    <param name="classifier_reliability" type="double" value="0.9"/>
-    <param name="do_continuous" type="bool" value="false" />
-    <param name="do_publish_faces_of_unknown_size" type="bool" value="false" />	
-    <param name="do_display" type="bool" value="false" />
-    <param name="use_rgbd" type="bool" value="true" />
-    <param name="approximate_sync" type="bool" value="true" />
-	 
-  </node>
-
+    <remap from="image_topic" to="$(arg image_topic)" />
+    <param name="fixed_frame" value="$(arg fixed_frame)" />
+  </include>
 </launch>

--- a/face_detector/launch/face_detector_action.wide.launch
+++ b/face_detector/launch/face_detector_action.wide.launch
@@ -3,19 +3,15 @@
   <arg name="camera" default="wide_stereo" />
   <arg name="image_topic" default="image_rect" />
   <arg name="fixed_frame" default="wide_stereo_optical_frame" />
-
-  <node pkg="face_detector" type="face_detector" name="face_detector" output="screen">
+  <arg name="use_rgbd" default="false" />  
+  <arg name="approximate_sync" default="false" />
+  
+  <include file="$(find face_detector)/launch/face_detector_common.launch">
     <remap from="camera" to="$(arg camera)" />
     <remap from="image" to="$(arg image_topic)" />
-    <param name="fixed_frame" type="string" value="$(arg fixed_frame)" />	
-    <param name="classifier_name" type="string" value="frontalface" />
-    <rosparam command="load" file="$(find face_detector)/param/classifier.yaml"/>
-    <param name="classifier_reliability" type="double" value="0.9"/>
-    <param name="do_continuous" type="bool" value="false" />
-    <param name="do_publish_faces_of_unknown_size" type="bool" value="false" />	
-    <param name="do_display" type="bool" value="false" />
-    <param name="use_rgbd" type="bool" value="false" />
-    <param name="approximate_sync" type="bool" value="false" />
-  </node>
+    <param name="fixed_frame" type="string" value="$(arg fixed_frame)" />
+    <param name="use_rgbd" type="bool" value="$(arg use_rgbd)" />
+    <param name="approximate_sync" type="bool" value="$(arg approximate_sync)" />
+  </include>
 
 </launch>

--- a/face_detector/launch/face_detector_common.launch
+++ b/face_detector/launch/face_detector_common.launch
@@ -1,0 +1,31 @@
+<launch>
+  <arg name="camera" default="camera" />
+  <arg name="rgb_ns" default="rgb" />
+  <arg name="depth_ns" default="depth_registered" />
+  <arg name="image_topic" default="image_rect_color" />
+  <arg name="depth_topic" default="image_rect_raw" />
+  <arg name="fixed_frame" default="camera_rgb_optical_frame" />
+  <arg name="classifier_name" default="frontalface" />
+  <arg name="paramfile_classifier" default="$(find face_detector)/param/classifier.yaml"/>
+  <arg name="classifier_reliability" default="0.9"/>
+  <arg name="do_continuous" default="false" />
+  <arg name="do_publish_faces_of_unknown_size" default="false" />	
+  <arg name="do_display" default="false" />
+  <arg name="use_rgbd" default="true" />
+  <arg name="approximate_sync" default="true" />
+
+  <node pkg="face_detector" type="face_detector" name="face_detector_action" output="screen">
+    <remap from="camera" to="$(arg camera)" />
+    <remap from="rgb_ns" to="$(arg rgb_ns)" />
+    <remap from="image" to="$(arg image_topic)" />
+    <param name="fixed_frame" type="string" value="$(arg fixed_frame)" />
+    <param name="classifier_name" type="string" value="frontalface" />
+    <rosparam command="load" file="$(arg paramfile_classifier)"/>
+    <param name="classifier_reliability" type="double" value="$(arg classifier_reliability)"/>
+    <param name="do_continuous" type="bool" value="$(arg do_continuous)" />
+    <param name="do_publish_faces_of_unknown_size" type="bool" value="$(arg do_publish_faces_of_unknown_size)" />	
+    <param name="do_display" type="bool" value="$(arg do_display)" />
+    <param name="use_rgbd" type="bool" value="$(arg use_rgbd)" />
+    <param name="approximate_sync" type="bool" value="$(arg approximate_sync)" />
+  </node>
+</launch>

--- a/face_detector/src/face_detection.cpp
+++ b/face_detector/src/face_detection.cpp
@@ -108,6 +108,7 @@ public:
   string depth_topic_;
   string camera_info_topic_;
   string depth_info_topic_;
+  string rgb_ns_;
   string depth_ns_;
 
   // Images and conversion for both the stereo camera and rgb-d camera cases.
@@ -241,8 +242,9 @@ public:
       camera_ = nh_.resolveName("camera");
       image_image_ = nh_.resolveName("image_topic");
       depth_image_ = nh_.resolveName("depth_topic");
+      rgb_ns_ = nh_.resolveName("rgb_ns");
       depth_ns_ = nh_.resolveName("depth_ns");
-      camera_topic_ = ros::names::clean(camera_ + "/rgb/" + image_image_);
+      camera_topic_ = ros::names::clean(camera_ + "/" + rgb_ns_ + "/" + image_image_);
       depth_topic_ = ros::names::clean(camera_ + "/" + depth_ns_ + "/" + depth_image_);
       camera_info_topic_ = ros::names::clean(camera_ + "/rgb/camera_info");
       depth_info_topic_ = ros::names::clean(camera_ + "/" + depth_ns_ + "/camera_info");


### PR DESCRIPTION
This PR addresses the following issues / concerns:
- Some topic examples introduced in https://github.com/wg-perception/people/pull/28 are wrong 
- A namespace for RGB camera [is hardcoded](https://github.com/wg-perception/people/blob/8935ab35a3b9b837d395269d6622cb257144f69c/face_detector/src/face_detection.cpp#L245)
- Multiple launch files in `face_detector/launch` declare the same node individually ([example](https://github.com/wg-perception/people/blob/0e9ae2cba94fc5e2cdcd4bb7103f67f0efee2364/face_detector/launch/face_detector.rgbd.launch#L20)), which can multiply the maintenance effort
