### PR TITLE
Fix missing clusters split while jumping back

### DIFF
--- a/leg_detector/src/laser_processor.cpp
+++ b/leg_detector/src/laser_processor.cpp
@@ -255,7 +255,7 @@ ScanProcessor::splitConnected(float thresh)
         while ((s_rest != (*c_iter)->end() &&
                 (*s_rest)->index < (*s_q)->index + expand))
         {
-          if ((*s_rest)->range - (*s_q)->range > thresh)
+          if (std::abs((*s_rest)->range - (*s_q)->range) > thresh)
           {
             break;
           }

--- a/leg_detector/src/leg_detector.cpp
+++ b/leg_detector/src/leg_detector.cpp
@@ -647,16 +647,16 @@ public:
             || (*leg1)->getReliability() < leg_reliability_limit_)
           continue;
 
-        for (leg2 = begin; leg2 != end; ++leg2)
+        for (leg2 = leg1,leg2++; leg2 != end; ++leg2)
         {
           if (((*leg2)->object_id != "")
-              || ((*leg2)->getReliability() < leg_reliability_limit_)
-              || (leg1 == leg2)) continue;
+              || ((*leg2)->getReliability() < leg_reliability_limit_)) continue;
           double d = distance(leg1, leg2);
           if (d < closest_dist)
           {
             best1 = leg1;
             best2 = leg2;
+            closest_dist = d;
           }
         }
       }


### PR DESCRIPTION
ScanProcessor::splitConnected(float thresh) currently only consider the situation that range increase suddenly but ignore sudden decrease. When  sudden decrease occurs, it will jump to "else" to "++s_rest". If range is far enough, "expand" will be 1 or 2, nothing happen. But  if range is very close, it may miss a jumping back， which will led to incorrect clusters split.

I think we just need to add a "std::abs(float)" to the "if"
      