### PR TITLE
Remove and move unused includes

### DIFF
--- a/face_detector/include/face_detector/faces.h
+++ b/face_detector/include/face_detector/faces.h
@@ -43,7 +43,6 @@
 
 
 
-#include <stdio.h>
 #include <iostream>
 #include <vector>
 

--- a/face_detector/include/face_detector/faces.h
+++ b/face_detector/include/face_detector/faces.h
@@ -43,7 +43,6 @@
 
 
 
-#include <iostream>
 #include <vector>
 
 #include <opencv/cv.hpp>

--- a/face_detector/include/face_detector/faces.h
+++ b/face_detector/include/face_detector/faces.h
@@ -50,8 +50,6 @@
 #include <opencv/cvaux.hpp>
 
 #include "image_geometry/stereo_camera_model.h"
-#include "ros/time.h"
-#include <ros/console.h>
 #include <boost/thread/mutex.hpp>
 #include <boost/bind.hpp>
 #include <boost/thread/thread.hpp>

--- a/face_detector/src/faces.cpp
+++ b/face_detector/src/faces.cpp
@@ -43,6 +43,9 @@
 #include <algorithm>
 #include <iostream>
 
+#include <ros/time.h>
+#include <ros/console.h>
+
 namespace people
 {
 

--- a/face_detector/src/faces.cpp
+++ b/face_detector/src/faces.cpp
@@ -41,6 +41,7 @@
 #include "face_detector/faces.h"
 #include <cfloat>
 #include <algorithm>
+#include <iostream>
 
 namespace people
 {


### PR DESCRIPTION
This PR removes/moves some unused includes.

* `stdio.h` was not used at all, so it's removed
* `iostream`, `ros/time.h`, and `ros/console.h` were only used in the cpp file, so they were moved there from the header