### PR TITLE
Document name field

### DIFF
--- a/people_msgs/msg/PositionMeasurement.msg
+++ b/people_msgs/msg/PositionMeasurement.msg
@@ -1,4 +1,5 @@
 std_msgs/Header     header
+# The name of the detector that detected the person (i.e frontalface, profileface)
 string              name
 string              object_id
 geometry_msgs/Point pos


### PR DESCRIPTION
Taken from this comment

https://github.com/wg-perception/people/blob/da3a91ae1c2373398105967c60d7eff98d7405fd/face_detector/src/face_detection.cpp#L166

Where the field `name_` is used to populate `name` in PositionMeasurement message 

https://github.com/wg-perception/people/blob/da3a91ae1c2373398105967c60d7eff98d7405fd/face_detector/src/face_detection.cpp#L613