### PR TITLE
Fix bfl include directory

### DIFF
--- a/people_tracking_filter/CMakeLists.txt
+++ b/people_tracking_filter/CMakeLists.txt
@@ -5,7 +5,7 @@ project(people_tracking_filter)
 find_package(PkgConfig)
 pkg_check_modules(BFL REQUIRED orocos-bfl)
 
-include_directories(${BFL_INCLUDE_DIRS})
+include_directories(${BFL_INCLUDE_DIRS}/bfl)
 link_directories(${BFL_LIBRARY_DIRS})
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
This fix is required to build `people_tracking_filter` when BFL is also built in the same workspace.

With this change the package also builds when BFL is installed from debians. The same fix was used in `cob_people_tracking_filter`, in this commit: https://github.com/ipa320/cob_people_perception/commit/650caf8d045da5366b5286b894d53aeb817fc19e