### PR TITLE
[kinetic] Fix BFL include directories

### DIFF
--- a/leg_detector/CMakeLists.txt
+++ b/leg_detector/CMakeLists.txt
@@ -46,7 +46,7 @@ catkin_package(
 )
 
 include_directories(
-  include ${catkin_INCLUDE_DIRS} ${BFL_INCLUDE_DIRS} ${BULLET_INCLUDE_DIRS}
+  include ${catkin_INCLUDE_DIRS} ${BFL_INCLUDE_DIRS}/.. ${BULLET_INCLUDE_DIRS}
 )
 
 add_executable(leg_detector

--- a/people_tracking_filter/CMakeLists.txt
+++ b/people_tracking_filter/CMakeLists.txt
@@ -32,7 +32,7 @@ catkin_package(
 )
 
 include_directories(
-  include ${catkin_INCLUDE_DIRS} ${BFL_INCLUDE_DIRS}/bfl
+  include ${catkin_INCLUDE_DIRS} ${BFL_INCLUDE_DIRS}/..
 )
 
 add_library(people_tracking_filter


### PR DESCRIPTION
Closes https://github.com/wg-perception/people/issues/96.

Tested both scenarios mentioned in #96:
* Having bfl in the same workspace
* Having `ros-kinetic-bfl` installed