### PR TITLE
[Noetic] Add missing dependency on yaml-cpp

### DIFF
--- a/face_detector/CMakeLists.txt
+++ b/face_detector/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 find_package(OpenCV)
+find_package(yaml-cpp REQUIRED)
 
 add_action_files(
   DIRECTORY action

--- a/face_detector/package.xml
+++ b/face_detector/package.xml
@@ -29,6 +29,7 @@
   <depend>stereo_image_proc</depend>
   <depend>stereo_msgs</depend>
   <depend>tf</depend>
+  <depend>yaml-cpp</depend>
 
   <build_depend>message_generation</build_depend>
   <build_export_depend>message_runtime</build_export_depend>


### PR DESCRIPTION
Maybe this will fix https://build.ros.org/job/Nbin_uF64__face_detector__ubuntu_focal_amd64__binary/9 . I have not built locally to confirm.

That job has been failing with

```
23:05:39 /tmp/binarydeb/ros-noetic-face-detector-1.4.0/src/face_detection.cpp:79:10: fatal error: yaml-cpp/yaml.h: No such file or directory
23:05:41    79 | #include <yaml-cpp/yaml.h>
23:05:41       |          ^~~~~~~~~~~~~~~~~
```

Which now seems to be causing a regression of `people` in Noetic: http://repositories.ros.org/status_page/ros_noetic_default.html?q=REGRESSION

`yaml-cpp` seems to be the right rosdep key. [`face_detector` is already using the `yaml-cpp` target](https://github.com/wg-perception/people/blob/66edc6fafe4ecb460f2b7898d2b68ae4b31c4b0f/face_detector/CMakeLists.txt#L67), but it must have been expecting to get it transitively.

```console
$ find /usr/include -name yaml.h
/usr/include/yaml-cpp/yaml.h
/usr/include/yaml.h
$ dpkg -S /usr/include/yaml-cpp/yaml.h
libyaml-cpp-dev: /usr/include/yaml-cpp/yaml.h
```

https://index.ros.org/d/yaml-cpp/