### PR TITLE
Fix rvalue error

### DIFF
--- a/face_detector/src/face_detection.cpp
+++ b/face_detector/src/face_detection.cpp
@@ -716,7 +716,9 @@ private:
           else
           {
             max_id_++;
-            pos.object_id = static_cast<std::ostringstream*>(&(std::ostringstream() << max_id_))->str();
+            std::ostringstream oss;
+            oss << max_id_;
+            pos.object_id = oss.str();
             ROS_INFO_STREAM_NAMED("face_detector", "Didn't find face to match, starting new ID " << pos.object_id);
           }
           result_.face_positions.push_back(pos);


### PR DESCRIPTION
Fixes
```
$SRC_DIR/ros-noetic-face-detector/src/work/src/face_detection.cpp:719:85: error: taking address of rvalue [-fpermissive]
  719 |             pos.object_id = static_cast<std::ostringstream*>(&(std::ostringstream() << max_id_))->str();
      |                                                               ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
ninja: build stopped: subcommand failed.
```